### PR TITLE
Search bar functionality; routed to personal pages

### DIFF
--- a/frontend_src/src/app/app.routes.ts
+++ b/frontend_src/src/app/app.routes.ts
@@ -5,7 +5,7 @@ import { Home } from './pages/home/home';
 
 export const routes: Routes = [
     {path: '', component: Home, pathMatch: 'full'},
-    {path: 'personal', component: Personal},
+    {path: 'personal/:id', component: Personal},
     {path: 'history', component: History},
     
 ];

--- a/frontend_src/src/app/pages/home/home.css
+++ b/frontend_src/src/app/pages/home/home.css
@@ -11,38 +11,44 @@ h1 {
 }
 
 .content-container {
+    width: 100%; /* Ensure full width of the parent container */
     display: flex;
-    justify-content: space-between; /* Adds space between the containers */
-    align-items: flex-start; /* Aligns containers to the top */
-    margin-top: 50px; /* Adds space below the header */
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-top: 50px;
+    gap: 50px;
 }
 
 .search-container {
-    width: 45%;
+    flex: 1;
+    width: 55%;
     display: flex;
     flex-direction: column; /* Stack header and search bar vertically */
     align-items: center; /* Center-align content */
     margin-top: 20px;
-    margin-left: 40px;
+    margin-left: 20px;
 }
 
 .stock-container {
-    width: 45%; /* Adjust width to fit side by side */
+    flex: 1;
+    width: 35%;
+    margin-right: -10px;
 }
 
 h2 {
     text-align: left;
     font-size: 2rem; /* Adjusted for better visibility */
 }
+
 /* ----- Looking at your stocks ------------ */
 .stock-box {
     position: relative;
     width: 70%; /* Adjust width as needed */
     height: auto; /* Adjust height based on content */
-    background-color: #f0f0f0; /* Light gray background */
+    background-color: #ffffff; /* Light gray background */
     border-radius: 10px; /* Rounded edges */
     margin-top: 10px; /* Adds spacing between the h2 and the box */
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Optional: Adds a subtle shadow */
     padding: 20px; /* Adds padding inside the box */
 }
 
@@ -58,7 +64,7 @@ h2 {
 }
 
 .stock-table th {
-    background-color: #e0e0e0; /* Light gray background for headers */
+    background-color:  #c5deef;
     font-weight: bold; /* Makes header text bold */
 }
 
@@ -82,37 +88,49 @@ h2 {
 /* ----- Searching Stocks ------------ */
 
 .search-bar-wrapper {
+    position: relative; /* Allows positioning of the button inside the wrapper */
+    width: 80%; /* Full width of the container */
     margin-top: 10px;
-    display: flex;
-    flex-direction: row;
-    align-items: center; /* Align input and button vertically */
-    width: 100%; /* Full width of the container */
+    align-items: right;
 }
 
 .search-bar {
-    flex: 1; /* Make the input take up remaining space */
+    width: 100%; /* Full width of the search bar */
     padding: 10px; /* Add padding inside the input */
     font-size: 16px; /* Adjust font size */
     border: 1px solid #ccc; /* Add a border */
-    border-radius: 5px 0 0 5px; /* Rounded corners on the left */
+    border-radius: 5px; /* Rounded corners */
 }
 
-.search-button {
-    background-color: #007bff; /* Button color */
-    color: white; /* Icon color */
-    border: none; /* Remove border */
-    border-radius: 0 5px 5px 0; /* Rounded corners on the right */
-    padding: 10px 15px; /* Adjust padding */
+
+
+.search-results {
+    margin-top: 20px;
+    padding: 10px;
+    background-color:  #ffffff;
+    
+}
+
+.results-container {
+    display: flex; /* Align stock boxes side by side */
+    flex-wrap: wrap; /* Allow wrapping to the next row if necessary */
+    gap: 10px; /* Space between stock boxes */
+    margin-top: 10px;
+}
+
+.result-box {
+    background-color: #c5deef; /* Light blue background */
+    padding: 10px; /* Padding inside the box */
+    text-align: center; /* Center-align text */
     cursor: pointer; /* Change cursor to pointer */
     display: flex;
     align-items: center;
     justify-content: center;
+    text-decoration: none; /* Remove underline for links */
+    border: none; /* Remove border */
+    border-radius: 10px; /* Add rounded corners */
 }
 
-.search-button i {
-    font-size: 16px; /* Adjust icon size */
-}
-
-.search-button:hover {
-    background-color: #0056b3; /* Darker blue on hover */
+.result-box:hover {
+    background-color: #90c7eb; /* Light gray background on hover */
 }

--- a/frontend_src/src/app/pages/home/home.html
+++ b/frontend_src/src/app/pages/home/home.html
@@ -9,10 +9,19 @@
     <div class="search-container">
         <h2>Select a stock to view:</h2>
         <div class="search-bar-wrapper">
-            <input type="text" class="search-bar" placeholder="Search stocks..." />
-            <button class="search-button">
-                <i class="fa fa-search"></i> <!-- Font Awesome icon for magnifying glass -->
-            </button>
+            <input 
+            type="text" 
+            class="search-bar" 
+            placeholder="Search stocks..."
+            [(ngModel)]="searchTerm"
+            (input)="filterStocks()"  />
+        </div>
+        <div class="search-results">
+            <div class="results-container">
+                <button class="result-box" *ngFor="let stock of filteredStocks" [routerLink]="['/personal', stock.id]">
+                    <h4>{{ stock.name }}</h4>
+                </button>
+            </div>
         </div>
     </div>
     <!--View of users stocks-->

--- a/frontend_src/src/app/pages/home/home.ts
+++ b/frontend_src/src/app/pages/home/home.ts
@@ -2,17 +2,20 @@ import { Component, OnInit} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { StockService } from '../../services/stock.service';
+import { FormsModule } from '@angular/forms'; // Import FormsModule
 
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './home.html',
   styleUrls: ['./home.css']
 })
 export class Home implements OnInit {
-  stocks: any[] = []; // Variable to hold stock data
+  stocks: any[] = []; // All stocks
+  filteredStocks: any[] = []; // Filtered stocks based on search
+  searchTerm: string = ''; // User's search input
 
   constructor(private stockService: StockService) {}
 
@@ -26,5 +29,16 @@ export class Home implements OnInit {
         console.error('Error fetching stock data:', error);
       }
     );
+  }
+
+  // Filter stocks based on the search term
+  filterStocks(): void {
+    if (this.searchTerm.trim() === '') {
+      this.filteredStocks = []; // Clear results if search term is empty
+    } else {
+      this.filteredStocks = this.stocks.filter(stock =>
+        stock.name.toLowerCase().includes(this.searchTerm.toLowerCase())
+      );
+    }
   }
 }

--- a/frontend_src/src/app/pages/personal/personal.ts
+++ b/frontend_src/src/app/pages/personal/personal.ts
@@ -1,11 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-personal',
+  standalone: true,
   imports: [],
   templateUrl: './personal.html',
   styleUrl: './personal.css'
 })
-export class Personal {
+export class Personal implements OnInit {
+  stockId: string | null = null;
 
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    // Retrieve the stock ID from the route parameters
+    this.stockId = this.route.snapshot.paramMap.get('id');
+  }
 }


### PR DESCRIPTION
Allowed to search the mock db in the search bar. Also added the results as seperate buttons which rout to that stock's personal page (at the moment they are indexed by an abritrary ID number)

<img width="1440" height="900" alt="Screenshot 2025-08-04 at 11 55 16" src="https://github.com/user-attachments/assets/f77ae74c-7c4a-443b-bef8-45ab23f797f8" />
<img width="1440" height="900" alt="Screenshot 2025-08-04 at 11 55 25" src="https://github.com/user-attachments/assets/06c7f0ea-a67c-4810-a5a2-8ca69727ce11" />
